### PR TITLE
Replace versions-comparison function

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ And there will be a json file in ./data/
 |   |-- API // pkg for request to API
 |   |-- logger // pkg for logging
 |   |-- IO // pkg for CLI control
+|   |-- VersionComprator// pkg for compare rpm versions
 |-- readme_assets // folder with files for README
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
 module test
 
 go 1.18
+

--- a/pkg/API/main.go
+++ b/pkg/API/main.go
@@ -12,8 +12,8 @@ var errorLoggerAPI = logger.NewLogger("api-main", "ERROR")
 
 var Client = &http.Client{}
 
-//getData make HTTP Request to API, and decode result to Response struct.
-//Takes as arguments branch`s name, arch param and Response struct
+// getData make HTTP Request to API, and decode result to Response struct.
+// Takes as arguments branch`s name, arch param and Response struct
 func getData(name, query string, response interface{}) error {
 	template := "https://rdb.altlinux.org/api/export/branch_binary_packages/"
 	r, err := Client.Get(template + name + query)
@@ -30,7 +30,7 @@ func getData(name, query string, response interface{}) error {
 	return json.NewDecoder(r.Body).Decode(response)
 }
 
-//response make map from Response struct
+// response make map from Response struct
 func responseToSet(response *Response) map[string]Package {
 	SetResponse := make(map[string]Package)
 	for _, pkg := range response.Packages {
@@ -46,7 +46,11 @@ func GetSet(name, query string) (map[string]Package, error) {
 	err := getData(name, query, response)
 	if err != nil {
 		errorLoggerAPI.Printf("GetSet %s", err.Error())
-		return nil, err
+		response = &Response{}
+		err := getData(name, query, response)
+		if err != nil {
+			return nil, err
+		}
 	}
 	setResponse := responseToSet(response)
 	infoLoggerAPI.Printf("GetSet have done")

--- a/pkg/API/utils.go
+++ b/pkg/API/utils.go
@@ -3,6 +3,7 @@ package API
 import (
 	"encoding/json"
 	"os"
+	"test/pkg/VersionsComparator"
 )
 
 func InSet(set map[string]Package, packName string) bool {
@@ -39,9 +40,10 @@ func Compare(first, second map[string]Package, path string) error {
 		if !InSet(second, name) {
 			difference.Add(1, pack)
 		} else {
-			if pack.Version > second[name].Version {
+			if VersionsComparator.SecondVersionLessFirst(pack.Version, second[name].Version) {
 				difference.Add(3, pack)
 			}
+
 			delete(second, name)
 		}
 		delete(first, name)

--- a/pkg/IO/main.go
+++ b/pkg/IO/main.go
@@ -9,10 +9,11 @@ import (
 func inputString() string {
 	print(":> ")
 	msg, _ := bufio.NewReader(os.Stdin).ReadString('\n')
-	return strings.Replace(msg, "\n", "", -1)
+	prepared := strings.Replace(msg, "\n", "", -1)
+	return strings.Replace(prepared, "\r", "", -1)
 }
 
-//Begin is entry point in IO. Asks for branches`s name
+// Begin is entry point in IO. Asks for branches`s name
 func Begin() (string, string) {
 	println("Hello!\nThis is app for comparing packages from different branches ALT Linux")
 	println("Enter first branch`s name")
@@ -22,7 +23,7 @@ func Begin() (string, string) {
 	return firstName, secondName
 }
 
-//AddQuery allows you to enter arch params
+// AddQuery allows you to enter arch params
 func AddQuery() string {
 	println("Do you want to add platform parameters?(y/n)")
 	ch := inputString()

--- a/pkg/VersionsComparator/main.go
+++ b/pkg/VersionsComparator/main.go
@@ -1,0 +1,140 @@
+package VersionsComparator
+
+import (
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+func newVersion(ver string) (version Version) {
+	var err error
+	splitted := strings.SplitN(ver, ":", 2)
+	if len(splitted) == 1 {
+		version.epoch = 0
+		ver = splitted[0]
+	} else {
+		epoch := strings.TrimLeftFunc(splitted[0], unicode.IsSpace)
+
+		version.epoch, err = strconv.Atoi(epoch)
+		if err != nil {
+			version.epoch = 0
+		}
+
+		ver = splitted[1]
+	}
+
+	index := strings.Index(ver, "-")
+	if index >= 0 {
+		version.version = ver[:index]
+		version.release = ver[index+1:]
+
+	} else {
+		version.version = ver
+	}
+
+	return version
+}
+
+func (v Version) lessThan(v1 Version) bool {
+	return v.compare(v1) < 0
+}
+
+func (v Version) compare(v1 Version) int {
+	if reflect.DeepEqual(v, v1) {
+		return 0
+	}
+	if v.epoch > v1.epoch {
+		return 1
+	} else if v.epoch < v1.epoch {
+		return -1
+	}
+	ret := rpmvercmp(v.version, v1.version)
+	if ret != 0 {
+		return ret
+	}
+	return rpmvercmp(v.release, v1.release)
+}
+
+// https://github.com/rpm-software-management/rpm/blob/master/lib/rpmvercmp.c#L16
+func rpmvercmp(a, b string) int {
+	if a == b {
+		return 0
+	}
+
+	// get alpha/numeric segements
+	segsa := alphs.FindAllString(a, -1)
+	segsb := alphs.FindAllString(b, -1)
+	segs := int(math.Min(float64(len(segsa)), float64(len(segsb))))
+
+	// compare each segment
+	for i := 0; i < segs; i++ {
+		a := segsa[i]
+		b := segsb[i]
+
+		// compare tildes
+		if []rune(a)[0] == '~' || []rune(b)[0] == '~' {
+			if []rune(a)[0] != '~' {
+				return 1
+			}
+			if []rune(b)[0] != '~' {
+				return -1
+			}
+		}
+
+		if unicode.IsNumber([]rune(a)[0]) {
+			// numbers are always greater than alphas
+			if !unicode.IsNumber([]rune(b)[0]) {
+				// a is numeric, b is alpha
+				return 1
+			}
+
+			// trim leading zeros
+			a = strings.TrimLeft(a, "0")
+			b = strings.TrimLeft(b, "0")
+
+			// longest string wins without further comparison
+			if len(a) > len(b) {
+				return 1
+			} else if len(b) > len(a) {
+				return -1
+			}
+
+		} else if unicode.IsNumber([]rune(b)[0]) {
+			// a is alpha, b is numeric
+			return -1
+		}
+
+		// string compare
+		if a < b {
+			return -1
+		} else if a > b {
+			return 1
+		}
+	}
+
+	// segments were all the same but separators must have been different
+	if len(segsa) == len(segsb) {
+		return 0
+	}
+
+	// If there is a tilde in a segment past the min number of segments, find it.
+	if len(segsa) > segs && []rune(segsa[segs])[0] == '~' {
+		return -1
+	} else if len(segsb) > segs && []rune(segsb[segs])[0] == '~' {
+		return 1
+	}
+
+	// whoever has the most segments wins
+	if len(segsa) > len(segsb) {
+		return 1
+	}
+	return -1
+}
+
+func SecondVersionLessFirst(v1, v2 string) bool {
+	vv1 := newVersion(v1)
+	vv2 := newVersion(v2)
+	return vv2.lessThan(vv1)
+}

--- a/pkg/VersionsComparator/main_test.go
+++ b/pkg/VersionsComparator/main_test.go
@@ -1,0 +1,44 @@
+package VersionsComparator
+
+import "testing"
+
+func TestSecondVersionLessFirst(t *testing.T) {
+	testTable := []struct {
+		v1       string
+		v2       string
+		expected bool
+	}{
+		{
+			v1:       "1.4.1",
+			v2:       "3.5",
+			expected: false,
+		},
+		{
+			v1:       "6.2.0",
+			v2:       "6.10.2",
+			expected: false,
+		},
+		{
+			v1:       "12",
+			v2:       "11",
+			expected: true,
+		},
+		{
+			v1:       "12.2",
+			v2:       "11",
+			expected: true,
+		},
+		{
+			v1:       "0.1.2",
+			v2:       "0.11.2",
+			expected: false,
+		},
+	}
+	for _, testCase := range testTable {
+		result := SecondVersionLessFirst(testCase.v1, testCase.v2)
+		t.Logf("V1 %s V2 %s, result %t\n", testCase.v1, testCase.v2, result)
+		if result != testCase.expected {
+			t.Errorf("Incorrect result. Expect %t, got %t", testCase.expected, result)
+		}
+	}
+}

--- a/pkg/VersionsComparator/models.go
+++ b/pkg/VersionsComparator/models.go
@@ -1,0 +1,11 @@
+package VersionsComparator
+
+import "regexp"
+
+var alphs = regexp.MustCompile("([a-zA-Z]+)|([0-9]+)|(~)")
+
+type Version struct {
+	epoch   int
+	version string
+	release string
+}


### PR DESCRIPTION
The version comparison function did not work correctly due to an attempt to compare versions in the form of strings. The new algorithm compares using a transformation. Problem arose due to the lack of tests, so they were added

- Fix: incorrect working versions-comparison function
- Refactor: versions-comparison function move to individual pkg(VersionsComparator)
- Add: Tests for function versions comparing
- Add: File with test results
- Docs: update README file with structure project